### PR TITLE
Sorted scoreboard in descending order

### DIFF
--- a/scripts/ball/handleTurnEnd.js
+++ b/scripts/ball/handleTurnEnd.js
@@ -43,16 +43,23 @@ function handleGameFinish() {
 
 	let overlayDivHtmlContent = getCelebratingDivElem({ cumulativeScoresArray });
 
-	overlayDivHtmlContent += `${cumulativeScoresArray
-		.map(
-			playerNameKeyWrapper((playerNameKey, score) =>
-				getScoreDetailDivElement({
-					playerName: PLAYER_NAME_KEY_LABEL_MAPPING[playerNameKey],
-					playerScore: score,
-				})
-			)
+	const outputContent = cumulativeScoresArray.map(
+		playerNameKeyWrapper((playerNameKey, score) =>
+			getScoreDetailDivElement({
+				playerName: PLAYER_NAME_KEY_LABEL_MAPPING[playerNameKey],
+				playerScore: score,
+			})
 		)
-		.join('')}`;
+	);
+	
+	// Sort outputContent based on cumulativeScoresArray values in descending order
+	const sortedOutput = outputContent
+	    .map((content, index) => ({ content, score: cumulativeScoresArray[index] }))
+	    .sort((a, b) => b.score - a.score)
+	    .map(item => item.content);
+
+
+	overlayDivHtmlContent += `${sortedOutput.join('')}`;
 
 	overlayDivHtmlContent += restartButton;
 


### PR DESCRIPTION
### Description
`closes` issue https://github.com/aakashdinkarh/bounce-and-collect-game/issues/33

Added logic in `handleGameFinish` method to sort the score board in descending order of scores.

### Screenshots

*Before* -
<img width="557" alt="Screenshot 2025-02-22 at 12 13 33 AM" src="https://github.com/user-attachments/assets/42c859b5-8fc0-47e6-b5d5-53be56d84c9c" />

*After* -
<img width="576" alt="Screenshot 2025-02-22 at 12 12 33 AM" src="https://github.com/user-attachments/assets/7fbf68ed-6c21-4d4b-814a-295d5603ddf7" />
